### PR TITLE
[FIX]  게시글 상세보기 토큰 requeired로 변화

### DIFF
--- a/src/main/java/com/wagu/wafl/api/config/jwt/JwtTokenManager.java
+++ b/src/main/java/com/wagu/wafl/api/config/jwt/JwtTokenManager.java
@@ -65,4 +65,15 @@ public class JwtTokenManager {
         final Claims claims = getBody(token);
         return (String) claims.get("sub"); // claims에 "sub"에 userId가 들어가는데 위에서 .subject를 수정해야 하나?
     }
+
+    public Long getUserIdFromJwt(String token) {
+        verifyToken(token);
+
+        final String tokenContents = getJwtContents(token);
+        try{
+            return Long.parseLong(tokenContents);
+        } catch (NumberFormatException e) {
+            throw new AuthException(ExceptionMessage.NOT_PARSED_TO_ID.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+    }
 }

--- a/src/main/java/com/wagu/wafl/api/domain/post/controller/PostController.java
+++ b/src/main/java/com/wagu/wafl/api/domain/post/controller/PostController.java
@@ -55,9 +55,8 @@ public class PostController {
             description = "게시글 내용 및 댓글 정보를 조회합니다."
     )
     @GetMapping("/detail/{postId}")
-
-    public ResponseEntity<ApiResponse> getPostDetail(@UserId Long userId, @PathVariable Long postId) {
-        val response = postService.getPostDetail(userId, postId);
+    public ResponseEntity<ApiResponse> getPostDetail(@RequestHeader(value = "Authorization", required = false) String accessToken, @PathVariable Long postId) { //@UserId Long userId
+        val response = postService.getPostDetail(accessToken, postId);
         return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_GET_POST_DETAIL.getMessage(), response));
     }
 }

--- a/src/main/java/com/wagu/wafl/api/domain/post/service/PostService.java
+++ b/src/main/java/com/wagu/wafl/api/domain/post/service/PostService.java
@@ -11,5 +11,5 @@ public interface PostService {
 
     List<OttPostsListResponseDTO> getOttPosts(List<OttTag> request);
     void createPost(Long userId, CreatePostRequestDTO createPostRequestDTO);
-    PostDetailResponseDTO getPostDetail(Long userId, Long postId);
+    PostDetailResponseDTO getPostDetail(String accessToken, Long postId);
 }


### PR DESCRIPTION
## Related Issue 🚀
- #50
<br>

## Work Description ✏️
- 게시글 상세보기 경우, 기존의 @UserId어노테이션을 사용하지 않고, Token을 선택적으로 받을 수 있게 처리했습니다.
- 또한 우리 서비스 유저가 아닐경우 UserId를 -1로 판단하여 처리합니다. 

<br>


###  스크린샷 (선택)



<br>

# Check
## Test Code Check
- [ ] repository 테스트 작성
- [ ] 메소드 테스트 작성
- [ ] 서비스 테스트 작성
- [ ] 테스트 못 한 메소드의 경우 //todo 로 표기
<br>

### Swagger Check
- [ ] 에러값 모두 작성
- [ ] 리턴값 모두 작성 

<br>

### Log Check
- [ ] 로그로 남길 부분이 있으며, 로그 표시를 완료 했나요?

<br>

### Query Check
- [ ] N+1과 같이 과도하게 쿼리가 나가는 부분이 있었나요?

<br>


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->


<br>



close #
